### PR TITLE
Fix visual glitch with chat room headers

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,7 +40,6 @@
 
 .rc-header__wrap {
     color: var(--header-title-status-color);
-    box-shadow: 0 3px 1px 2px rgba(255, 255, 255, 0.1);
 }
 
 .rc-user-info__name {


### PR DESCRIPTION
I noticed a visual glitch (an unsightly border/shadow) on the chat room headers after installing the user style on a Rocket.Chat instance. Here's a screenshot:

![rc-header-theme-glitch](https://user-images.githubusercontent.com/10786787/82242552-0b82cc00-990c-11ea-9f86-a5c711ebec08.png)

It seems as though removing `box-shadow` on `.rc-header__wrap` fixes the issue, so I've removed it. Looks fine now:

![rc-header-fixed](https://user-images.githubusercontent.com/10786787/82242787-73d1ad80-990c-11ea-940b-08dbae5d3fdd.png)