### PR TITLE
Various text readability fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,10 @@
     border-color: var(--color-dark-medium);
 }
 
+.rc-message-box__typing-user {
+    color: var(--color-gray-light);
+}
+
 .rc-button:not(.rc-button--primary) {
     color: var(--color-gray-medium);
     border-color: var(--color-dark-medium);
@@ -122,6 +126,10 @@ textarea {
     background: var(--color-darkest);
 }
 
+.rc-modal__title {
+    color: var(--color-gray-medium);
+}
+
 .message.new-day::before,
 .flex-tab .message.new-day::before {
     background-color: var(--color-darkest);
@@ -162,7 +170,11 @@ textarea {
     background: var(--mention-link-background);
 }
 
-.contextual-bar {
+.contextual-bar__header {
     background: var(--color-darkest);
     box-shadow: 0 3px 1px 2px rgba(255, 255, 255, 0.1);
+}
+
+.role-tag {
+    color: var(--color-dark);
 }


### PR DESCRIPTION
A set of text readability fixes. (ex. white on white or black on black)

Specifically:

- Typing indicators are no longer black on black
- The "Create a New Channel" popover no longer has a black-on-black title
- The "User Info" sidebar is now fully dark, with properly contrasting text. (there was an un-themed section with a fully white background)

I tested this on Rocket.Chat on Chrome using the [Stylus](https://github.com/openstyles/stylus) extension. Have not tested it as a Rocket.Chat admin.